### PR TITLE
remove asterisk13 from nethserver-freepbx requires

### DIFF
--- a/nethserver-freepbx.spec
+++ b/nethserver-freepbx.spec
@@ -8,7 +8,7 @@ BuildArch: noarch
 
 BuildRequires: nethserver-devtools
 
-Requires: asterisk13, freepbx
+Requires: freepbx
 Requires: rh-php56, rh-php56-php-fpm
 Requires: rh-php56-php-mysql, rh-php56-php-pear, rh-php56-php-pdo
 Requires: rh-php56-php-process, rh-php56-php-xml, rh-php56-php-mbstring


### PR DESCRIPTION
remove asterisk13 from nethserver-freepbx requires: it's already required by freepbx. NethServer/dev#5074
http://community.nethserver.org/t/asterisk-13-and-freepbx-14-on-nethserver-7/4003/26
