### PR TITLE
nethserver-freepbx-conf-users action: encode unicode passwords using PHP

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
@@ -37,6 +37,10 @@ if ($sssd->port == 636) {
     $security = 'tls';
 }
 
+$passwordUnicode = $sssd->bindPassword;
+$password = `/usr/bin/php -r "echo json_encode('$passwordUnicode');"`;
+$password =~ s/^"|"$//g;
+
 if ($sssd->isLdap) {
     my $userdn = $sssd->bindDN;
     $settings{'auth-settings'} = encode_json ({
@@ -46,7 +50,7 @@ if ($sssd->isLdap) {
         ssl => ($security = 'ssl' ? JSON::true : JSON::false),
         basedn => $sssd->baseDN,
         username => $sssd->bindUser,
-        password => $sssd->bindPassword,
+        password => $password,
         userident => 'cn',
         displayname => 'gecos',
         userdn => $sssd->baseDN,
@@ -61,7 +65,7 @@ if ($sssd->isLdap) {
         port => $sssd->port,
         dn => $sssd->userDN,
         username => $sssd->bindUser,
-        password => $sssd->bindPassword,
+        password => $password,
         domain => $db->get('sssd')->prop('Realm'),
         connection => $security,
         localgroups => '0',


### PR DESCRIPTION
perl allow to encode unicode json in a similar way, but result is dofferent from what FreePBX expect, so this fix spawn php to encode unicode password before putting it into mysql. 