### PR TITLE
nethserver-freepbx-conf-users: allow LDAP users to login to amp interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,3 +126,13 @@ To check user synchronization, use this command: ::
  /usr/bin/scl enable rh-php56 -- /usr/sbin/fwconsole userman --syncall --force --verbose
 
 Syncronization need a secure connection, use SSL or enable ``STARTTLS`` in ``Account Provider`` configuration in NethServer Web GUI
+
+Update from legacy OpenLDAP driver to OpenLDAP2 driver
+------------------------------------------------------
+
+Since nethserver-freepbx-14.0.5, if NethServer users are configured using OpenLDAP, FreePBX users are configured using FreePBX OpenLDAP 2 driver instead of legacy one.
+If you have installed nethserver-freepbx before 14.0.5, and your user provider is configured using LDAP, you're using legacy driver. You can check in FreePBX User Manager module interface if NethServer LDAP driver is "OpenLDAP Directory (Legacy)"
+
+Updating from legacy driver to the new one, allows to permit access to FreePBX interface and UCP to LDAP users, but migration isn't automatical because users would lose default extension associated and other custom options.
+The openldap_migration_from_legacy script, does the driver migration and restore users default_extensions. Other custom users options could be lost anyway.
+To execute migration, launch `# /usr/src/freepbx/openldap_migration_from_legacy`

--- a/nethserver-freepbx.spec
+++ b/nethserver-freepbx.spec
@@ -60,6 +60,7 @@ mkdir -p %{buildroot}/%{_localstatedir}/log/httpd-fpbx
 %config(noreplace) /etc/sysconfig/httpd-fpbx
 %config /etc/dahdi/system.conf
 
+
 %changelog
 * Wed Oct 25 2017 Stefano Fancello <stefano.fancello@nethesis.it> - 14.0.2-1
 - Configure voicemail ODBC storage NethServer/dev#5363

--- a/nethserver-freepbx.spec
+++ b/nethserver-freepbx.spec
@@ -60,7 +60,6 @@ mkdir -p %{buildroot}/%{_localstatedir}/log/httpd-fpbx
 %config(noreplace) /etc/sysconfig/httpd-fpbx
 %config /etc/dahdi/system.conf
 
-
 %changelog
 * Wed Oct 25 2017 Stefano Fancello <stefano.fancello@nethesis.it> - 14.0.2-1
 - Configure voicemail ODBC storage NethServer/dev#5363

--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
@@ -127,15 +127,18 @@ my $dbh = DBI->connect("DBI:mysql:database=asterisk;host=localhost","root",$mysq
 if ($sssd->isLdap or $sssd->isAD) {
     # Check if there is a NethServer AD or LDAP already configured and gets its id
     my $id;
-    my $sth = $dbh->prepare("SELECT id,name FROM `userman_directories` WHERE `name` LIKE 'NethServer LDAP%' OR `name` LIKE 'NethServer AD%'");
+    my $sth = $dbh->prepare("SELECT id,name,driver FROM `userman_directories` WHERE `name` LIKE 'NethServer LDAP%' OR `name` LIKE 'NethServer AD%'");
     $sth->execute();
     if (my $ref = $sth->fetchrow_hashref()) {
         $id = $ref->{'id'};
-        if (($ref->{'name'} eq 'NethServer LDAP') or ($ref->{'name'} eq 'NethServer AD')) {
+        if ((($ref->{'name'} eq 'NethServer LDAP') or ($ref->{'name'} eq 'NethServer AD')) and ($ref->{'driver'} ne 'Openldap')) {
             # Update configuration
             $dbh->do("UPDATE IGNORE kvstore_FreePBX_modules_Userman SET `key`='auth-settings', `val`='" . $settings{'auth-settings'} . "',`type`='json-arr' WHERE `id`=".$id."");
             $dbh->do("UPDATE IGNORE `userman_directories` SET `name`='" . $settings{'name'} . "',`driver`='" . $settings{'driver'} . "', `active`=1, `order`=5, `default`=1, `locked`=0 WHERE `name`='" . $ref->{'name'} . "'");
-        }
+        } elsif (($ref->{'driver'} eq 'Openldap') and ($ref->{'name'} eq 'NethServer LDAP')) {
+	    # Change driver name to NethServer LDAP legacy
+	    $dbh->do("UPDATE IGNORE `userman_directories` SET `name`='NethServer LDAP legacy' WHERE `name`='" . $ref->{'name'} . "'");
+	}
         $sth->finish();
     } else {
         # Set defautl to 0 for other userman_directories

--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
@@ -42,22 +42,43 @@ $password = `/usr/bin/php -r "echo json_encode('$passwordUnicode');"`;
 $password =~ s/^"|"$//g;
 
 if ($sssd->isLdap) {
-    my $userdn = $sssd->bindDN;
     $settings{'auth-settings'} = encode_json ({
         host => $sssd->host,
         port => $sssd->port,
-        tls => ($security = 'tls' ? JSON::true : JSON::false),
-        ssl => ($security = 'ssl' ? JSON::true : JSON::false),
         basedn => $sssd->baseDN,
-        username => $sssd->bindUser,
+        username => $sssd->bindDN,
         password => $password,
-        userident => 'cn',
         displayname => 'gecos',
-        userdn => $sssd->baseDN,
+        userdn => 'ou=People',
+        connection => $security,
+        localgroups => '0',
+        createextensions => '',
+        externalidattr => 'entryUUID',
+        descriptionattr => 'description',
+        commonnameattr => 'uid',
+        userobjectclass => 'posixAccount',
+        userobjectfilter => '(objectclass=posixAccount)',
+        usernameattr => 'uid',
+        userfirstnameattr => 'givenName',
+        userlastnameattr => 'sn',
+        userdisplaynameattr => 'gecos',
+        usertitleattr => '',
+        usercompanyattr => '',
+        usercellphoneattr => '',
+        userworkphoneattr => 'telephoneNumber',
+        userhomephoneattr => 'homephone',
+        userfaxphoneattr => 'facsimileTelephoneNumber',
+        usermailattr => 'mail',
+        usergroupmemberattr => 'memberOf',
         la => '',
+        groupnameattr => 'cn',
+        groupdnaddition => 'ou=Groups',
+        groupobjectclass => 'posixGroup',
+        groupobjectfilter => '(objectclass=posixGroup)',
+        groupmemberattr => 'memberUid',
         sync => '0 * * * *'
     });
-    $settings{'driver'} = 'Openldap';
+    $settings{'driver'} = 'Openldap2';
     $settings{'name'} = 'NethServer LDAP';
 } elsif($sssd->isAD) {
     $settings{'auth-settings'} = encode_json ({

--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf-users
@@ -132,15 +132,16 @@ if ($sssd->isLdap or $sssd->isAD) {
     if (my $ref = $sth->fetchrow_hashref()) {
         $id = $ref->{'id'};
         if ((($ref->{'name'} eq 'NethServer LDAP') or ($ref->{'name'} eq 'NethServer AD')) and ($ref->{'driver'} ne 'Openldap')) {
-            # Update configuration
+            # Update configuration if name in NethServer LDAP or NethServer AD but LDAP driver isn't legacy Openldap
             $dbh->do("UPDATE IGNORE kvstore_FreePBX_modules_Userman SET `key`='auth-settings', `val`='" . $settings{'auth-settings'} . "',`type`='json-arr' WHERE `id`=".$id."");
             $dbh->do("UPDATE IGNORE `userman_directories` SET `name`='" . $settings{'name'} . "',`driver`='" . $settings{'driver'} . "', `active`=1, `order`=5, `default`=1, `locked`=0 WHERE `name`='" . $ref->{'name'} . "'");
         } elsif (($ref->{'driver'} eq 'Openldap') and ($ref->{'name'} eq 'NethServer LDAP')) {
-	    # Change driver name to NethServer LDAP legacy
+	    # Change driver name to NethServer LDAP legacy if directory is configured with LDAP legacy driver
 	    $dbh->do("UPDATE IGNORE `userman_directories` SET `name`='NethServer LDAP legacy' WHERE `name`='" . $ref->{'name'} . "'");
 	}
         $sth->finish();
     } else {
+	# Directory isn't already configured, create a new configuration
         # Set defautl to 0 for other userman_directories
         $dbh->do("UPDATE IGNORE `userman_directories` SET `default` = 0");
         # Create entry for NethServer AD/LDAP in userman_directories

--- a/root/usr/src/freepbx/openldap_migration_from_legacy
+++ b/root/usr/src/freepbx/openldap_migration_from_legacy
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+# 
+# This script is part of NethServer.
+# 
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+# 
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#####################################################################################
+# This script help migrating from old OpenLdap Legacy driver to new OpenLDAP driver #
+# Is only useful if you installed nethserver-freepbx <= 14.0.4                      #
+#####################################################################################
+
+USEREXT=$(mktemp)
+/usr/bin/mysql asterisk -B --silent -e "SELECT username,default_extension FROM userman_users" | awk '{print $1,"|",$2}' | sed 's/ //g' >$USEREXT
+/usr/bin/mysql asterisk -B --silent -e "UPDATE userman_directories SET name='NethServer LDAP' WHERE name='NethServer LDAP legacy'"
+/usr/bin/mysql asterisk -B --silent -e "UPDATE userman_directories SET driver='Openldap2' WHERE name='NethServer LDAP'"
+
+# clear users
+/etc/e-smith/events/actions/nethserver-freepbx-conf-users &>/dev/null
+
+# fetch new users
+/usr/bin/scl enable rh-php56 -- /usr/sbin/fwconsole userman --syncall --force --verbose
+
+# restore users default extension
+for USER in $(cat $USEREXT); do 
+    username=$(echo $USER | cut -d\| -f1)
+    defalt_extension=$(echo $USER | cut -d\| -f2)
+    if [[ "defalt_extension" != 'none' ]]; then
+        /usr/bin/mysql asterisk -B --silent -e "UPDATE userman_users SET default_extension='$defalt_extension' WHERE username='$username'"
+    fi
+done
+rm -f $USEREXT


### PR DESCRIPTION
use Openldap2 driver instead of legacy Openldap and allow LDAP users to login to amp interface if they are allowed