### PR TITLE
nethserver-freepbx-conf action: create Asterisk user home dir if doesn't exist

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf
@@ -67,5 +67,10 @@ sed -i 's/memory_limit = 128M/memory_limit = 256M/' /etc/opt/rh/rh-php56/php.ini
 #Use bash shell for asterisk user
 echo "Making sure asterisk user has bash as shell" >> /var/log/freepbx_rpm_install.log
 /usr/sbin/usermod --shell /bin/bash asterisk &>> /var/log/freepbx_rpm_install.log
+#Check Asterisk user has home dir
+if [[ ! -d /home/asterisk ]]; then
+    echo "Creating Asterisk user home dir" >> /var/log/freepbx_rpm_install.log
+    /usr/sbin/mkhomedir_helper asterisk &>> /var/log/freepbx_rpm_install.log
+fi
 
 exit 0


### PR DESCRIPTION
FreePBX install script needs asterisk user to have an home dir, but if Asterisk RPM is installed using kickstart, /var/lib/nethserver/home isn't mounted on /home on Asterisk installation and asterisk home disappear once it's mounted, before FreePBX install script is launched. Now the action creates home directory if it's missing.