### PR TITLE
Force user sync when a new user is created

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -66,3 +66,6 @@ templates2events("/etc/httpd/conf.d/freepbx.conf", "interface-update");
 event_services($event, qw(
     httpd reload
 ));
+
+# sync freepbx users after user create
+event_link("nethserver-freepbx-userman-sync", "user-create", "91");

--- a/nethserver-freepbx.spec
+++ b/nethserver-freepbx.spec
@@ -5,6 +5,7 @@ Summary: NethServer configuration for FreePBX
 License: GPL
 Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
+URL: %{url_prefix}/%{name}
 
 BuildRequires: nethserver-devtools
 BuildRequires: systemd

--- a/root/etc/e-smith/events/actions/nethserver-freepbx-userman-sync
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-userman-sync
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+/usr/bin/scl enable rh-php56 -- /usr/sbin/fwconsole userman --syncall --force -q


### PR DESCRIPTION
If user provider is on localhost, this fix allow to see users immediately after creation