### PR TITLE
Fix backup restore

### DIFF
--- a/root/etc/backup-config.d/freepbx.exclude
+++ b/root/etc/backup-config.d/freepbx.exclude
@@ -1,0 +1,2 @@
+/etc/amportal.conf
+/etc/asterisk/manager.conf

--- a/root/etc/backup-config.d/freepbx.include
+++ b/root/etc/backup-config.d/freepbx.include
@@ -3,4 +3,3 @@
 /var/lib/asterisk/licenses
 /etc/asterisk
 /etc/dahdi
-/etc/freepbx.conf

--- a/root/etc/e-smith/events/actions/nethserver-freepbx-backup-restore
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-backup-restore
@@ -66,6 +66,9 @@ if ( -r "$astdir/asterisk.dump")
 	#require "apply changes"
 	system("/usr/bin/mysql asterisk --defaults-file=/root/.my.cnf -e 'update admin set value=\"true\" where variable=\"need_reload\"' &> /dev/null");
 	unlink "$astdir/asterisk.dump";
+        my $managerpwd = `/usr/bin/mysql --defaults-file=/root/.my.cnf -BN asterisk -e 'select value from freepbx_settings where keyword = "AMPMGRPASS"'`;
+        $managerpwd =~ s/\n//;
+        system("/usr/bin/sed -i 's/^secret = .*/secret = ".$managerpwd."/g' /etc/asterisk/manager.conf");
 } else {
     print ("[INFO] Asterisk mysql database backup doesn't exist\n");
 }


### PR DESCRIPTION
- remove /etc/freepbx.conf from backup, otherwise new FreePBX installation during restore fails
- remove /etc/amportal.conf from backup, otherwise new FreePBX installation during restore fails
- remove /etc/asterisk/manager.conf from backup. It is created again
- take old manager password from restored mysql db and write it into manager.conf