### PR TITLE
Use PHP 5.6 SCL environment for AGI executed by Asterisk

### DIFF
--- a/root/usr/lib/systemd/system/asterisk.service
+++ b/root/usr/lib/systemd/system/asterisk.service
@@ -6,6 +6,8 @@ Wants=systemd-modules-load.service
 [Service]
 Type=simple
 Environment=HOME=/var/lib/asterisk
+Environment=PATH=/opt/rh/rh-php56/root/usr/bin:/opt/rh/rh-php56/root/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=LD_LIBRARY_PATH=/opt/rh/rh-php56/root/usr/lib64
 WorkingDirectory=/var/lib/asterisk
 RuntimeDirectory=asterisk
 RuntimeDirectoryMode=0775


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5499

current path is
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
LD_LIBRARY_PATH is not setted

unfortunately, isn't possible to use variables here (like PATH=foo:$PATH)