### PR TITLE
Allows bigger file upload in PHP configuration

### DIFF
--- a/root/etc/opt/rh/rh-php56/php-fpm.d/fpbx.conf
+++ b/root/etc/opt/rh/rh-php56/php-fpm.d/fpbx.conf
@@ -26,3 +26,6 @@ php_admin_flag[log_errors] = on
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/run/httpd-fpbx
 php_value[soap.wsdl_cache_dir]  = /var/run/httpd-fpbx
+
+php_value[upload_max_filesize] = 20M
+php_value[post_max_size] = 20M


### PR DESCRIPTION
increase post_max_size and upload_max_filesize from default (2Mb) to 20Mb
https://github.com/NethServer/dev/issues/5701