### PR TITLE
Apply asterisk permissions also to /var/log/astersik/freepbx.log

### DIFF
--- a/root/etc/e-smith/templates/etc/asterisk/freepbx_chown.conf/60custom
+++ b/root/etc/e-smith/templates/etc/asterisk/freepbx_chown.conf/60custom
@@ -1,2 +1,3 @@
 directory = /var/lib/asterisk/sounds/en/,0755,asterisk,asterisk
 file = /etc/asterisk/http_custom.conf,0644,asterisk,asterisk
+file = /var/log/asterisk/freepbx.log,0640,asterisk,asterisk


### PR DESCRIPTION
if /var/log/astersik/freepbx.log is missing, it is created as root:root if reload is launched by root from shell

this minor issue emerged during development of https://github.com/nethesis/dev/issues/5640