### PR TITLE
Missing shebang in clean cel script

### DIFF
--- a/root/etc/cron.daily/fpbx_clean_cel
+++ b/root/etc/cron.daily/fpbx_clean_cel
@@ -1,2 +1,24 @@
 #!/bin/bash
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# Cleanup CEL records older than 180 days
 /usr/bin/mysql asteriskcdrdb  --defaults-file=/root/.my.cnf -e 'DELETE  FROM `cel` WHERE `eventtime` < NOW() - INTERVAL 180 DAY' &>/dev/null

--- a/root/etc/cron.daily/fpbx_clean_cel
+++ b/root/etc/cron.daily/fpbx_clean_cel
@@ -1,1 +1,2 @@
+#!/bin/bash
 /usr/bin/mysql asteriskcdrdb  --defaults-file=/root/.my.cnf -e 'DELETE  FROM `cel` WHERE `eventtime` < NOW() - INTERVAL 180 DAY' &>/dev/null


### PR DESCRIPTION
Clean cel script, delete cel logs older than 180 days.
CEL is an asterisk very verbose call log that keeps trace of every event that occur into the channel.
Because of missing shebang in this script, cel wasn't cleaned

https://github.com/NethServer/dev/issues/6204