### PR TITLE
Wait for asterisk startup completion

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf
@@ -36,13 +36,6 @@ mkdir -p /var/lib/asterisk/sounds/custom/
 
 # wait for asterisk
 systemctl start asterisk
-for i in $(seq 0 300); do
-    /usr/sbin/asterisk -rx "core show version" &>> /dev/null
-    if [[ $(echo $?) == 0 ]] ; then
-        break
-    fi
-    sleep 1
-done
 
 touch /var/log/asterisk/fail2ban
 touch /var/log/asterisk/freepbx_security.log

--- a/root/usr/lib/systemd/system/asterisk.service
+++ b/root/usr/lib/systemd/system/asterisk.service
@@ -14,10 +14,10 @@ RuntimeDirectoryMode=0775
 User=asterisk
 Group=asterisk
 ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
-ExecStartPost=/bin/bash -c "while ! /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; done"
-ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version') != Asterisk* ]]; do sleep 1; done"
+ExecStartPost=/bin/bash -c "while ! /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; ((++attempt<30)) || exit 2; done"
+ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version') != Asterisk* ]]; do sleep 1; ((++attempt<30)) || exit 2; done"
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
-ExecStopPost=/bin/bash -c "while /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; done"
+ExecStopPost=/bin/bash -c "while /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; ((++attempt<30)) || exit 2; done"
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
 
 # To emulate some of the features of the safe_asterisk script, copy

--- a/root/usr/lib/systemd/system/asterisk.service
+++ b/root/usr/lib/systemd/system/asterisk.service
@@ -14,10 +14,8 @@ RuntimeDirectoryMode=0775
 User=asterisk
 Group=asterisk
 ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
-ExecStartPost=/bin/bash -c "while ! /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; ((++attempt<30)) || exit 2; done"
-ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version') != Asterisk* ]]; do sleep 1; ((++attempt<30)) || exit 2; done"
+ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version' 2>/dev/null) != Asterisk* ]]; do ((++attempt<30)) || exit 2; sleep 1 ; done"
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
-ExecStopPost=/bin/bash -c "while /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; ((++attempt<30)) || exit 2; done"
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
 
 # To emulate some of the features of the safe_asterisk script, copy

--- a/root/usr/lib/systemd/system/asterisk.service
+++ b/root/usr/lib/systemd/system/asterisk.service
@@ -14,6 +14,8 @@ RuntimeDirectoryMode=0775
 User=asterisk
 Group=asterisk
 ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
+ExecStartPost=/bin/bash -c "while ! /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; done"
+ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version') != Asterisk* ]]; do sleep 1; done"
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
 

--- a/root/usr/lib/systemd/system/asterisk.service
+++ b/root/usr/lib/systemd/system/asterisk.service
@@ -17,6 +17,7 @@ ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
 ExecStartPost=/bin/bash -c "while ! /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; done"
 ExecStartPost=/bin/bash -c "while [[ $$(/usr/sbin/asterisk -rx 'core show version') != Asterisk* ]]; do sleep 1; done"
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
+ExecStopPost=/bin/bash -c "while /usr/sbin/asterisk -rx 'core show version' &>/dev/null; do sleep 1; done"
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
 
 # To emulate some of the features of the safe_asterisk script, copy


### PR DESCRIPTION
Check that the service is ready to serve console connections before considering it as "started".

This seems to be required by the FreePBX install script, as it seeks a started and ready asterisk instance.

The `ExecStartPost=` scripts try up to 30 times to contact the running asterisk service. If one of them fails the unit enters the FAILED state and an automatic startup is scheduled by systemd.

Note that the order of ExecStartPost is fixed. At first only the connection is checked, then the second script makes sure the asterisk response is correct.

The existing service startup poll loop should be redundant and is removed by this PR.

https://github.com/NethServer/dev/issues/6305