### PR TITLE
Load mysql credentials

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-freepbx-restore-db-access
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-restore-db-access
@@ -29,7 +29,7 @@ try {
 } catch (Exception $e) {
     if (strpos($e->getMessage(), "Access denied for user 'freepbxuser'") !== false) {
         echo "[NOTICE] Fixing database access for user 'freepbuser'\n";
-        $cmd = "/usr/bin/mysql mysql -e \"set password for 'freepbxuser'@'localhost' = PASSWORD('{$amp_conf['AMPDBPASS']}');\"";
+        $cmd = "/usr/bin/mysql --defaults-file=/root/.my.cnf mysql -e \"set password for 'freepbxuser'@'localhost' = PASSWORD('{$amp_conf['AMPDBPASS']}');\"";
         system($cmd);
    }
 }


### PR DESCRIPTION
When action is executed by an event, it's $HOME isn't /root and there aren't the mysql credentials loaded to execute queries as root without password
https://github.com/NethServer/dev/issues/6352