### PR TITLE
Don't overwrite retrieve_conf if Framework already support Asterisk 18

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-freepbx-conf-scl
+++ b/root/etc/e-smith/events/actions/nethserver-freepbx-conf-scl
@@ -22,9 +22,12 @@
 
 # check if fpbx is already installed
 if [[ -f /var/www/html/freepbx/index.php ]] ; then
-    # check if installed retrieve_conf is different from the packaged one and copy it
-    diff -q /usr/src/freepbx/amp_conf/bin/retrieve_conf /var/lib/asterisk/bin/retrieve_conf
-    if [[ $? == 1 ]]; then
+    diff -q /usr/src/freepbx/amp_conf/bin/retrieve_conf /var/lib/asterisk/bin/retrieve_conf >/dev/null
+    files_differ=$?
+    grep -q 'if (version_compare($version, "11", "lt") || version_compare($version, "17", "ge")) {' /var/lib/asterisk/bin/retrieve_conf
+    version_control=$?
+    if [[ $files_differ == 1 && $version_control == 0 ]]; then
+        echo "Patching /var/lib/asterisk/bin/retrieve_conf to allow Asterisk 18"
         /bin/cp /usr/src/freepbx/amp_conf/bin/retrieve_conf /var/lib/asterisk/bin/retrieve_conf
     fi
 


### PR DESCRIPTION
Framework module updates retrieve_conf, if a newer version of Framework module is already installed (that is totally possible on community version), it already support Asterisk 18 and overwriting it could break it
https://github.com/Nethesis/dev/issues/6124